### PR TITLE
Only extract ffmpeg and ffprobe from the tarball

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ RUN buildDeps='wget' && \
   python -m pip install --upgrade setuptools && \
   python -m pip install pyssim && \
   wget http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz && \
-  tar xf ffmpeg-release-64bit-static.tar.xz && \
-  mv ffmpeg*/ffmpeg /usr/bin/ && \
-  mv ffmpeg*/ffprobe /usr/bin/ && \
+  tar --strip-components 1 -C /usr/bin -xf ffmpeg-release-64bit-static.tar.xz */ffmpeg */ffprobe && \
   rm ffmpeg-release-64bit-static.tar.xz && \
   apt-get purge -y --auto-remove $buildDeps \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN buildDeps='wget' && \
   python -m pip install --upgrade pip && \
   python -m pip install --upgrade setuptools && \
   python -m pip install pyssim && \
-  wget http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz && \
+  wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz && \
   tar --strip-components 1 -C /usr/bin -xf ffmpeg-release-64bit-static.tar.xz */ffmpeg */ffprobe && \
   rm ffmpeg-release-64bit-static.tar.xz && \
   apt-get purge -y --auto-remove $buildDeps \


### PR DESCRIPTION
Avoid leaving behind the expanded tarball contents by grabbing just the ffmpeg and ffprobe files.