### PR TITLE
Clean up Dockerfile: fix masked failures, drop dead code, swap image …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,23 @@
-FROM sitespeedio/node:ubuntu-24-04-nodejs-24.14.0
+FROM sitespeedio/node:ubuntu-24-04-nodejs-24.15.0
 
-ARG TARGETPLATFORM
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
-RUN export BUILD=$(if [ "$TARGETPLATFORM" = "linux/amd64" ] ; then echo "amd64"; else echo "arm64"; fi) \
-  buildDeps='wget ca-certificates build-essential' && \
-  apt-get update -y && apt-get install -y --no-install-recommends software-properties-common ca-certificates; \
+RUN buildDeps='wget build-essential software-properties-common' && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends $buildDeps && \
   add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg7 && \
-  apt-get update -y && apt-get install -y \
-  libjpeg-dev \
-  imagemagick \
-  python3-venv \
-  python3 \
-  xz-utils \
-  ffmpeg \
-  $buildDeps \
-  --no-install-recommends --force-yes && \
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
+    libjpeg-dev \
+    imagemagick \
+    python3-venv \
+    xz-utils \
+    ffmpeg && \
   python3 -m venv /opt/venv && \
-  /opt/venv/bin/pip install --upgrade pip setuptools && \
-  /opt/venv/bin/pip install --no-cache-dir pyssim OpenCV-Python Numpy image && \
-  apt-get purge -y --auto-remove $buildDeps
+  /opt/venv/bin/pip install --no-cache-dir pyssim opencv-python numpy Pillow && \
+  apt-get purge -y --auto-remove $buildDeps && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV PATH="/opt/venv/bin:${PATH}"
-CMD [ "python", "--version" ]
+CMD ["python", "--version"]


### PR DESCRIPTION
…→ Pillow

  The previous Dockerfile had a ; instead of && between two apt-get
  steps, so a failure in the first install would no longer halt the build.
  It also computed a BUILD variable from TARGETPLATFORM that nothing
  read, passed --force-yes (removed from apt years ago), and installed
  the abandoned image PyPI package — last released in 2020 and pulling
  in Django as a transitive dep. The actual dependency we want is Pillow.

  Consolidate to a single, fail-fast RUN, add software-properties-common
  to the build-only deps so it gets purged with the rest, and drop the
  redundant python3 package (already required by python3-venv) and the
  unnecessary pip install --upgrade pip setuptools inside a fresh venv.

  Co-authored-by: Claude noreply@anthropic.com